### PR TITLE
Retry concurrency error

### DIFF
--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Api/Admin/GameStateController.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Api/Admin/GameStateController.cs
@@ -27,7 +27,7 @@ namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Api.Admin
         [Route("post")]
         [HttpPost]
         [Obsolete] // Skjule for Swagger-apidoc
-        public async Task<HttpResponseMessage> PostGameState([FromBody]GameState modell)
+        public virtual async Task<HttpResponseMessage> PostGameState([FromBody]GameState modell)
         {
             if (modell == null)
                 return Request.CreateErrorResponse(HttpStatusCode.BadRequest, "Ugyldig request");

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Api/Admin/InfisertController.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Api/Admin/InfisertController.cs
@@ -62,7 +62,7 @@
         [HttpPost]
         [Route("post")]
         [Obsolete] // Skjule for Swagger-apidoc
-        public async Task<HttpResponseMessage> Post([FromBody] InfisertPolygon modell)
+        public virtual async Task<HttpResponseMessage> Post([FromBody] InfisertPolygon modell)
         {
             if (modell == null || modell.Koordinater == null) 
                 return OpprettErrorResponse(ErrorResponseType.UgyldigInputFormat, "Modell er ugyldig.");

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Api/Admin/LagController.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Api/Admin/LagController.cs
@@ -74,7 +74,7 @@ namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Api.Admin
         [Route("post")]
         [HttpPost]
         [Obsolete] // Skjule for Swagger-apidoc
-        public async Task<HttpResponseMessage> PostLag([FromBody]Lag modell)
+        public virtual async Task<HttpResponseMessage> PostLag([FromBody]Lag modell)
         {
             try
             {
@@ -165,7 +165,7 @@ namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Api.Admin
         [Route("tildelpoeng")]
         [HttpPost]
         [Obsolete] // Skjule for Swagger-apidoc
-        public async Task<HttpResponseMessage> TildelPoeng([FromBody]PoengInputModell inputModell)
+        public virtual async Task<HttpResponseMessage> TildelPoeng([FromBody]PoengInputModell inputModell)
         {
             if (inputModell == null)
                 return Request.CreateErrorResponse(HttpStatusCode.BadRequest, "Ugyldig request");
@@ -182,7 +182,7 @@ namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Api.Admin
         [Route("oppretthendelse")]
         [HttpPost]
         [Obsolete] // Skjule for Swagger-apidoc
-        public async Task<HttpResponseMessage> OpprettHendelse([FromBody]LoggHendelseInputModell inputModell)
+        public virtual async Task<HttpResponseMessage> OpprettHendelse([FromBody]LoggHendelseInputModell inputModell)
         {
             if (inputModell == null)
                 return Request.CreateErrorResponse(HttpStatusCode.BadRequest, "Ugyldig request");

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Api/Admin/PostController.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Api/Admin/PostController.cs
@@ -59,7 +59,7 @@ namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Api.Admin
         [Route("post")]
         [HttpPost]
         [Obsolete] // Skjule for Swagger-apidoc
-        public async Task<HttpResponseMessage> PostPost([FromBody]Post modell)
+        public virtual async Task<HttpResponseMessage> PostPost([FromBody]Post modell)
         {
             if (modell == null)
                 return Request.CreateErrorResponse(HttpStatusCode.BadRequest, "Ugyldig request");

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Api/Game/BaseGameController.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Api/Game/BaseGameController.cs
@@ -107,7 +107,7 @@
         [Route("sendpifmelding")]
         [ResponseType(typeof(HttpResponseMessage))]
         [HttpPost]
-        public async Task<HttpResponseMessage> SendPifMelding([FromBody] MeldingInputModell inputModell)
+        public virtual async Task<HttpResponseMessage> SendPifMelding([FromBody] MeldingInputModell inputModell)
         {
             if (inputModell == null)
                 return OpprettErrorResponse(ErrorResponseType.UgyldigInputFormat, "Modellen er ugyldig");

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Api/Game/PifGameController.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Api/Game/PifGameController.cs
@@ -42,7 +42,7 @@
         [Route("sendpifposisjon")]
         [ResponseType(typeof(HttpResponseMessage))]
         [HttpPost]
-        public async Task<HttpResponseMessage> SendPifPosisjon([FromBody] PifPosisjonInputModell inputModell)
+        public virtual async Task<HttpResponseMessage> SendPifPosisjon([FromBody] PifPosisjonInputModell inputModell)
         {
             if (inputModell == null)
                 return OpprettErrorResponse(ErrorResponseType.UgyldigInputFormat, "Modellen er ugyldig");
@@ -68,7 +68,7 @@
         [Route("sendpostkode")]
         [ResponseType(typeof(HttpResponseMessage))]
         [HttpPost]
-        public async Task<HttpResponseMessage> SendPostKode([FromBody] PostInputModell inputModell)
+        public virtual async Task<HttpResponseMessage> SendPostKode([FromBody] PostInputModell inputModell)
         {
             if (inputModell == null)
                 return OpprettErrorResponse(ErrorResponseType.UgyldigInputFormat, "Modellen er ugyldig");

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Bouvet.BouvetBattleRoyale.Applikasjon.Owin.csproj
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Bouvet.BouvetBattleRoyale.Applikasjon.Owin.csproj
@@ -79,6 +79,7 @@
     <Compile Include="BaseApiController.cs" />
     <Compile Include="Filters\AddAuthorizationRequiredResponseCodes.cs" />
     <Compile Include="Filters\UnhandledExceptionAttribute.cs" />
+    <Compile Include="Interception\RetryInterceptor.cs" />
     <Compile Include="log4netAutofacModule.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />
@@ -118,6 +119,14 @@
     <Reference Include="Autofac.Integration.WebApi.Owin">
       <HintPath>..\packages\Autofac.WebApi2.Owin.3.2.0\lib\net45\Autofac.Integration.WebApi.Owin.dll</HintPath>
     </Reference>
+    <Reference Include="AutofacContrib.DynamicProxy, Version=2.3.2.632, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\AutofacContrib.DynamicProxy.2.3.2.632\lib\net40\AutofacContrib.DynamicProxy.dll</HintPath>
+    </Reference>
+    <Reference Include="Castle.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Castle.Core.3.1.0\lib\net40-client\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="FakeItEasy">
       <HintPath>..\packages\FakeItEasy.1.24.0\lib\net40\FakeItEasy.dll</HintPath>
     </Reference>
@@ -126,6 +135,10 @@
     </Reference>
     <Reference Include="Microsoft.AspNet.SignalR.Core">
       <HintPath>..\packages\Microsoft.AspNet.SignalR.Core.2.1.2\lib\net45\Microsoft.AspNet.SignalR.Core.dll</HintPath>
+    </Reference>
+    <Reference Include="Microsoft.Azure.Documents.Client, Version=0.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Microsoft.Azure.Documents.Client.0.9.0-preview\lib\net40\Microsoft.Azure.Documents.Client.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Owin">

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Bouvet.BouvetBattleRoyale.Applikasjon.Owin.csproj
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Bouvet.BouvetBattleRoyale.Applikasjon.Owin.csproj
@@ -82,9 +82,7 @@
     <Compile Include="Interception\ConcurrencyProblemRetryStrategy.cs" />
     <Compile Include="Interception\RetryInterceptor.cs" />
     <Compile Include="Interception\SynchronousRetryInterceptor.cs" />
-    <Compile Include="Interception\TaskHelper2.cs" />
     <Compile Include="Interception\TaskHelper.cs" />
-    <Compile Include="Interception\TaskHelper3.cs" />
     <Compile Include="log4netAutofacModule.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Bouvet.BouvetBattleRoyale.Applikasjon.Owin.csproj
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Bouvet.BouvetBattleRoyale.Applikasjon.Owin.csproj
@@ -79,7 +79,12 @@
     <Compile Include="BaseApiController.cs" />
     <Compile Include="Filters\AddAuthorizationRequiredResponseCodes.cs" />
     <Compile Include="Filters\UnhandledExceptionAttribute.cs" />
+    <Compile Include="Interception\ConcurrencyProblemRetryStrategy.cs" />
     <Compile Include="Interception\RetryInterceptor.cs" />
+    <Compile Include="Interception\SynchronousRetryInterceptor.cs" />
+    <Compile Include="Interception\TaskHelper2.cs" />
+    <Compile Include="Interception\TaskHelper.cs" />
+    <Compile Include="Interception\TaskHelper3.cs" />
     <Compile Include="log4netAutofacModule.cs" />
     <Compile Include="Program.cs" />
     <Compile Include="Properties\AssemblyInfo.cs" />

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/ConcurrencyProblemRetryStrategy.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/ConcurrencyProblemRetryStrategy.cs
@@ -7,7 +7,13 @@ using System.Threading.Tasks;
 
 namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception
 {
-    public class ConcurrencyProblemRetryStrategy
+    public interface IRetryStrategy
+    {
+        bool ShouldRetry { get; }
+        TimeSpan RetryAfter { get; }
+    }
+
+    public class ConcurrencyProblemRetryStrategy : IRetryStrategy
     {
         public bool ShouldRetry { get; set; }
         public TimeSpan RetryAfter { get; set;}

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/ConcurrencyProblemRetryStrategy.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/ConcurrencyProblemRetryStrategy.cs
@@ -1,0 +1,35 @@
+﻿using Microsoft.Azure.Documents;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception
+{
+    public class ConcurrencyProblemRetryStrategy
+    {
+        public bool ShouldRetry { get; set; }
+        public TimeSpan RetryAfter { get; set;}
+
+        public ConcurrencyProblemRetryStrategy(Exception ex)
+        {
+            ShouldRetry = false;
+            RetryAfter = TimeSpan.Zero;
+
+            if (ex is AggregateException && ex.InnerException != null)
+                ex = ex.InnerException;
+
+            if (ex.InnerException is DocumentClientException)
+            {
+                var documentException = (DocumentClientException)ex.InnerException;
+
+                if (documentException.Error.Code == "PreconditionFailed")
+                {
+                    RetryAfter = documentException.RetryAfter;
+                    ShouldRetry = true;
+                }
+            }
+        }        
+    }
+}

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/RetryInterceptor.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/RetryInterceptor.cs
@@ -12,6 +12,65 @@ namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception
 {
     public class RetryInterceptor : IInterceptor
     {
+        public int ShouldTry { get; set; }
+
+        private void ProceedAndRetry(IInvocation invocation, int retryCount) 
+        {
+            try
+            {
+                invocation.Proceed();
+
+                var task = invocation.ReturnValue as Task;
+                if (task != null)
+                {
+                    if (retryCount < ShouldTry)
+                    {
+                        invocation.ReturnValue = task.ContinueWith(t =>
+                        {                            
+                            if (t.IsFaulted)
+                                OnException(invocation, t.Exception, retryCount);
+                        });
+                    }
+                }               
+            }
+            catch (Exception ex)
+            {
+                OnException(invocation, ex, retryCount);
+            }
+        }
+
+        private void OnException(IInvocation invocation, Exception ex, int retryCount) 
+        {
+            if (ex is AggregateException && ex.InnerException != null)
+                ex = ex.InnerException;
+
+            if (ex.InnerException is DocumentClientException)
+            {
+                var documentException = (DocumentClientException)ex.InnerException;
+
+                if (documentException.Error.Code == "PreconditionFailed")
+                {
+                    if (documentException.RetryAfter > TimeSpan.Zero)
+                        Thread.Sleep(documentException.RetryAfter);
+
+                    retryCount++;
+
+                    if(retryCount > ShouldTry)
+                        throw ex;
+
+                    ProceedAndRetry(invocation, retryCount);
+                }
+                else
+                {
+                    throw ex;
+                }
+            }
+            else
+            {
+                throw ex;
+            }
+        }
+
         public void Intercept(IInvocation invocation)
         {
             if (!invocation.Method.GetCustomAttributes(typeof(HttpPostAttribute), false).Any())
@@ -20,35 +79,38 @@ namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception
                 return;
             }
 
-            int maxRetry = 3;
-            int retryCount = 0;
+            ProceedAndRetry(invocation, 0);
 
-            while (retryCount <= maxRetry)
-            {
-                try
-                {
-                    invocation.Proceed();
-                }
-                catch (Exception ex)
-                {
-                    if (ex.InnerException is DocumentClientException)
-                    {
-                        var documentException = (DocumentClientException)ex.InnerException;
+            //int retryCount = 0;
 
-                        if (documentException.Error.Code == "PreconditionFailed")
-                        {
-                            if (documentException.RetryAfter > TimeSpan.Zero)
-                                Thread.Sleep(documentException.RetryAfter);
+            //while (retryCount <= ShouldTry)
+            //{
+            //    try
+            //    {
+            //        invocation.Proceed();
+            //    }
+            //    catch (Exception ex)
+            //    {
+            //        OnException(invocation, ex);
 
-                            retryCount++;
-                            continue;
-                        }
-                    }
+            //        if (ex.InnerException is DocumentClientException)
+            //        {
+            //            var documentException = (DocumentClientException)ex.InnerException;
 
-                    // Passthrough: Raise original exception
-                    throw;
-                }
-            }
+            //            if (documentException.Error.Code == "PreconditionFailed")
+            //            {
+            //                if (documentException.RetryAfter > TimeSpan.Zero)
+            //                    Thread.Sleep(documentException.RetryAfter);
+
+            //                retryCount++;
+            //                continue;
+            //            }
+            //        }
+
+            //        // Passthrough: Raise original exception
+            //        throw;
+            //    }
+            //}
         }
     }
 }

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/RetryInterceptor.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/RetryInterceptor.cs
@@ -1,0 +1,54 @@
+﻿using Castle.DynamicProxy;
+using Microsoft.Azure.Documents;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception
+{
+    public class RetryInterceptor : IInterceptor
+    {
+        public void Intercept(IInvocation invocation)
+        {
+            if (!invocation.Method.GetCustomAttributes(typeof(HttpPostAttribute), false).Any())
+            {
+                invocation.Proceed();
+                return;
+            }
+
+            int maxRetry = 3;
+            int retryCount = 0;
+
+            while (retryCount <= maxRetry)
+            {
+                try
+                {
+                    invocation.Proceed();
+                }
+                catch (Exception ex)
+                {
+                    if (ex.InnerException is DocumentClientException)
+                    {
+                        var documentException = (DocumentClientException)ex.InnerException;
+
+                        if (documentException.Error.Code == "PreconditionFailed")
+                        {
+                            if (documentException.RetryAfter > TimeSpan.Zero)
+                                Thread.Sleep(documentException.RetryAfter);
+
+                            retryCount++;
+                            continue;
+                        }
+                    }
+
+                    // Passthrough: Raise original exception
+                    throw;
+                }
+            }
+        }
+    }
+}

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/SynchronousRetryInterceptor.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/SynchronousRetryInterceptor.cs
@@ -1,0 +1,48 @@
+﻿using Castle.DynamicProxy;
+using Microsoft.Azure.Documents;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception
+{
+    public class SynchronousRetryInterceptor : IInterceptor
+    {
+        public int MaxAttempts { get; set; }
+
+        public void Intercept(IInvocation invocation)
+        {
+            if (!invocation.Method.GetCustomAttributes(typeof(HttpPostAttribute), false).Any())
+            {
+                invocation.Proceed();
+                return;
+            }
+
+            int retryCount = 0;
+
+            while (retryCount <= MaxAttempts)
+            {
+                try
+                {
+                    invocation.Proceed();
+                }
+                catch (Exception ex)
+                {
+                    var strategy = new ConcurrencyProblemRetryStrategy(ex);
+
+                    if (!strategy.ShouldRetry)
+                        throw;
+
+                    if (strategy.RetryAfter > TimeSpan.Zero)
+                        Thread.Sleep(strategy.RetryAfter);
+
+                    retryCount++;
+                }
+            }
+        }
+    }
+}

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/TaskHelper.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/TaskHelper.cs
@@ -1,4 +1,5 @@
-﻿using System;
+﻿using log4net;
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
@@ -9,13 +10,15 @@ namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception
 {
     public static class TaskHelper
     {
-        public static Task Retry(Task initialTask, Func<Task> taskProvider, int maxAttemps, Func<Exception, IRetryStrategy> getRetryStrategy)
+        public static TaskContinuationOptions TaskContinuationOptions = TaskContinuationOptions.ExecuteSynchronously;
+
+        public static Task Retry(Task initialTask, Func<Task> taskProvider, int maxAttemps, Func<Exception, IRetryStrategy> getRetryStrategy, ILog logger)
         {
             return initialTask
-                .ContinueWith(task => RetryContinuation(task, taskProvider, maxAttemps, getRetryStrategy), TaskContinuationOptions.ExecuteSynchronously);
-        }    
+                .ContinueWith(task => RetryContinuation(task, taskProvider, maxAttemps, getRetryStrategy, logger), TaskContinuationOptions);
+        }
 
-        public static Task RetryContinuation(Task task, Func<Task> taskProvider, int attemptsRemaining, Func<Exception, IRetryStrategy> getRetryStrategy)
+        public static Task RetryContinuation(Task task, Func<Task> taskProvider, int attemptsRemaining, Func<Exception, IRetryStrategy> getRetryStrategy, ILog logger)
         {
             if (task.IsFaulted)
             {
@@ -24,11 +27,16 @@ namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception
                 if (attemptsRemaining > 0 && retryStrategy.ShouldRetry)
                 {
                     if (retryStrategy.RetryAfter > TimeSpan.Zero)
-                        Thread.Sleep(retryStrategy.RetryAfter);
+                        Thread.Sleep(retryStrategy.RetryAfter); // Burde nok brukt noe Task.Delay-aktig her
+
+                    logger.WarnFormat("{0}: Retrying faulted task. Attempts remaining: {1}", typeof(TaskHelper).FullName, attemptsRemaining);
 
                     return taskProvider()
-                        .ContinueWith(retryTask => RetryContinuation(retryTask, taskProvider, --attemptsRemaining, getRetryStrategy), TaskContinuationOptions.ExecuteSynchronously);
+                        .ContinueWith(retryTask => RetryContinuation(retryTask, taskProvider, --attemptsRemaining, getRetryStrategy, logger), TaskContinuationOptions);
                 }
+
+                if(attemptsRemaining == 0)
+                    logger.WarnFormat("{0}: Retried faulted task. Giving up after last retry.", typeof(TaskHelper).FullName);
             }           
             return task;
         }       

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/TaskHelper.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/TaskHelper.cs
@@ -2,29 +2,35 @@
 using System.Collections.Generic;
 using System.Linq;
 using System.Text;
+using System.Threading;
 using System.Threading.Tasks;
 
 namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception
 {
     public static class TaskHelper
     {
-        public static Task Retry(Task initialTask, Func<Task> taskProvider, int maxAttemps, Func<Exception, bool> shouldRetry)
+        public static Task Retry(Task initialTask, Func<Task> taskProvider, int maxAttemps, Func<Exception, IRetryStrategy> getRetryStrategy)
         {
             return initialTask
-                .ContinueWith(task => RetryContinuation(task, taskProvider, maxAttemps, shouldRetry), TaskContinuationOptions.ExecuteSynchronously);
+                .ContinueWith(task => RetryContinuation(task, taskProvider, maxAttemps, getRetryStrategy), TaskContinuationOptions.ExecuteSynchronously);
         }    
 
-        public static Task RetryContinuation(Task task, Func<Task> taskProvider, int attemptsRemaining, Func<Exception, bool> shouldRetry)
+        public static Task RetryContinuation(Task task, Func<Task> taskProvider, int attemptsRemaining, Func<Exception, IRetryStrategy> getRetryStrategy)
         {
             if (task.IsFaulted)
             {
-                if (attemptsRemaining > 0 && shouldRetry(task.Exception.InnerException))
+                var retryStrategy = getRetryStrategy(task.Exception.InnerException);
+
+                if (attemptsRemaining > 0 && retryStrategy.ShouldRetry)
                 {
+                    if (retryStrategy.RetryAfter > TimeSpan.Zero)
+                        Thread.Sleep(retryStrategy.RetryAfter);
+
                     return taskProvider()
-                        .ContinueWith(retryTask => RetryContinuation(retryTask, taskProvider, --attemptsRemaining, shouldRetry), TaskContinuationOptions.ExecuteSynchronously);
+                        .ContinueWith(retryTask => RetryContinuation(retryTask, taskProvider, --attemptsRemaining, getRetryStrategy), TaskContinuationOptions.ExecuteSynchronously);
                 }
             }           
             return task;
-        }
+        }       
     }
 }

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/TaskHelper.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Interception/TaskHelper.cs
@@ -1,0 +1,30 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+
+namespace Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception
+{
+    public static class TaskHelper
+    {
+        public static Task Retry(Task initialTask, Func<Task> taskProvider, int maxAttemps, Func<Exception, bool> shouldRetry)
+        {
+            return initialTask
+                .ContinueWith(task => RetryContinuation(task, taskProvider, maxAttemps, shouldRetry), TaskContinuationOptions.ExecuteSynchronously);
+        }    
+
+        public static Task RetryContinuation(Task task, Func<Task> taskProvider, int attemptsRemaining, Func<Exception, bool> shouldRetry)
+        {
+            if (task.IsFaulted)
+            {
+                if (attemptsRemaining > 0 && shouldRetry(task.Exception.InnerException))
+                {
+                    return taskProvider()
+                        .ContinueWith(retryTask => RetryContinuation(retryTask, taskProvider, --attemptsRemaining, shouldRetry), TaskContinuationOptions.ExecuteSynchronously);
+                }
+            }           
+            return task;
+        }
+    }
+}

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Startup.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Startup.cs
@@ -88,7 +88,8 @@
             var builder = new ContainerBuilder();
             builder.RegisterModule<log4netAutofacModule>();
 
-            builder.RegisterInstance(new RetryInterceptor { MaxAttempts = 3 }).AsSelf().SingleInstance();
+            builder.RegisterType<RetryInterceptor>().AsSelf();
+            // Note controller methods must be virtual to be intercepted
             builder.RegisterApiControllers(Assembly.GetExecutingAssembly()).EnableClassInterceptors().InterceptedBy(typeof(RetryInterceptor));
            
             builder.RegisterType<Konfigurasjon>().As<IKonfigurasjon>();

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Startup.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Startup.cs
@@ -36,8 +36,11 @@
 
     using Newtonsoft.Json.Serialization;
 
+    using AutofacContrib.DynamicProxy;
+
     using Swashbuckle;
     using Swashbuckle.Application;
+    using Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception;
 
     public class Startup
     {
@@ -84,8 +87,10 @@
         {
             var builder = new ContainerBuilder();
             builder.RegisterModule<log4netAutofacModule>();
-            builder.RegisterApiControllers(Assembly.GetExecutingAssembly());
 
+            builder.RegisterInstance(new RetryInterceptor { ShouldTry = 3 }).AsSelf().SingleInstance();
+            builder.RegisterApiControllers(Assembly.GetExecutingAssembly()).EnableClassInterceptors().InterceptedBy(typeof(RetryInterceptor));
+           
             builder.RegisterType<Konfigurasjon>().As<IKonfigurasjon>();
             builder.RegisterType<DocumentDbContext>().As<IDocumentDbContext>().SingleInstance();
 

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Startup.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Startup.cs
@@ -88,7 +88,7 @@
             var builder = new ContainerBuilder();
             builder.RegisterModule<log4netAutofacModule>();
 
-            builder.RegisterInstance(new RetryInterceptor { ShouldTry = 3 }).AsSelf().SingleInstance();
+            builder.RegisterInstance(new RetryInterceptor { MaxAttempts = 3 }).AsSelf().SingleInstance();
             builder.RegisterApiControllers(Assembly.GetExecutingAssembly()).EnableClassInterceptors().InterceptedBy(typeof(RetryInterceptor));
            
             builder.RegisterType<Konfigurasjon>().As<IKonfigurasjon>();

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/packages.config
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/packages.config
@@ -5,6 +5,8 @@
   <package id="Autofac.SignalR" version="3.0.1" targetFramework="net45" />
   <package id="Autofac.WebApi2" version="3.4.0" targetFramework="net45" />
   <package id="Autofac.WebApi2.Owin" version="3.2.0" targetFramework="net45" />
+  <package id="AutofacContrib.DynamicProxy" version="2.3.2.632" targetFramework="net45" />
+  <package id="Castle.Core" version="3.1.0" targetFramework="net45" />
   <package id="FakeItEasy" version="1.24.0" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.Cors" version="5.2.2" targetFramework="net45" />
@@ -16,6 +18,7 @@
   <package id="Microsoft.AspNet.WebApi.Owin" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.OwinSelfHost" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Tracing" version="5.2.2" targetFramework="net45" />
+  <package id="Microsoft.Azure.Documents.Client" version="0.9.0-preview" targetFramework="net45" />
   <package id="Microsoft.Owin" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Diagnostics" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.0" targetFramework="net45" />

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.WebHost/docs/BouvetCodeCamp.xml
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.WebHost/docs/BouvetCodeCamp.xml
@@ -100,15 +100,5 @@
              <response code="400">Bad request</response>
              <response code="500">Internal Server Error</response>
         </member>
-        <member name="T:Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception.TaskHelper2">
-            <summary>
-            Utility methods for <see cref="T:System.Threading.Tasks.Task"/>.
-            </summary>
-        </member>
-        <member name="T:Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception.TaskHelper">
-            <summary>
-            Utility methods for <see cref="T:System.Threading.Tasks.Task"/>.
-            </summary>
-        </member>
     </members>
 </doc>

--- a/Bouvet.BouvetBattleRoyale.Applikasjon.WebHost/docs/BouvetCodeCamp.xml
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.WebHost/docs/BouvetCodeCamp.xml
@@ -100,5 +100,15 @@
              <response code="400">Bad request</response>
              <response code="500">Internal Server Error</response>
         </member>
+        <member name="T:Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception.TaskHelper2">
+            <summary>
+            Utility methods for <see cref="T:System.Threading.Tasks.Task"/>.
+            </summary>
+        </member>
+        <member name="T:Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception.TaskHelper">
+            <summary>
+            Utility methods for <see cref="T:System.Threading.Tasks.Task"/>.
+            </summary>
+        </member>
     </members>
 </doc>

--- a/Bouvet.BouvetBattleRoyale.Integrasjonstester/Bouvet.BouvetBattleRoyale.Integrasjonstester.csproj
+++ b/Bouvet.BouvetBattleRoyale.Integrasjonstester/Bouvet.BouvetBattleRoyale.Integrasjonstester.csproj
@@ -72,6 +72,9 @@
     <Reference Include="Microsoft.Owin.Security">
       <HintPath>..\packages\Microsoft.Owin.Security.3.0.0\lib\net45\Microsoft.Owin.Security.dll</HintPath>
     </Reference>
+    <Reference Include="Moq">
+      <HintPath>..\packages\Moq.4.2.1409.1722\lib\net40\Moq.dll</HintPath>
+    </Reference>
     <Reference Include="Newtonsoft.Json, Version=6.0.0.0, Culture=neutral, PublicKeyToken=30ad4fe6b2a6aeed, processorArchitecture=MSIL">
       <SpecificVersion>False</SpecificVersion>
       <HintPath>..\packages\Newtonsoft.Json.6.0.5\lib\net45\Newtonsoft.Json.dll</HintPath>

--- a/Bouvet.BouvetBattleRoyale.Integrasjonstester/Bouvet.BouvetBattleRoyale.Integrasjonstester.csproj
+++ b/Bouvet.BouvetBattleRoyale.Integrasjonstester/Bouvet.BouvetBattleRoyale.Integrasjonstester.csproj
@@ -40,6 +40,14 @@
     <Reference Include="Autofac">
       <HintPath>..\packages\Autofac.3.5.2\lib\net40\Autofac.dll</HintPath>
     </Reference>
+    <Reference Include="AutofacContrib.DynamicProxy, Version=2.3.2.632, Culture=neutral, PublicKeyToken=17863af14b0044da, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\AutofacContrib.DynamicProxy.2.3.2.632\lib\net40\AutofacContrib.DynamicProxy.dll</HintPath>
+    </Reference>
+    <Reference Include="Castle.Core, Version=3.1.0.0, Culture=neutral, PublicKeyToken=407dd0808d44fbdc, processorArchitecture=MSIL">
+      <SpecificVersion>False</SpecificVersion>
+      <HintPath>..\packages\Castle.Core.3.1.0\lib\net40-client\Castle.Core.dll</HintPath>
+    </Reference>
     <Reference Include="FizzWare.NBuilder">
       <HintPath>..\packages\NBuilder.3.0.1.1\lib\FizzWare.NBuilder.dll</HintPath>
     </Reference>
@@ -111,6 +119,7 @@
     <Compile Include="Api\PostControllerTests.cs" />
     <Compile Include="DataAksess\LagRepositoryIntegrasjonstester.cs" />
     <Compile Include="DataAksess\PostRepositoryIntegrasjonstester.cs" />
+    <Compile Include="Infrastructure\RetryInterceptionTests.cs" />
     <Compile Include="TestManager.cs" />
     <Compile Include="Testkategorier.cs" />
     <Compile Include="DataAksess\BaseRepositoryIntegrasjonstest.cs" />

--- a/Bouvet.BouvetBattleRoyale.Integrasjonstester/Infrastructure/RetryInterceptionTests.cs
+++ b/Bouvet.BouvetBattleRoyale.Integrasjonstester/Infrastructure/RetryInterceptionTests.cs
@@ -1,0 +1,193 @@
+﻿using Autofac;
+using Autofac.Core;
+using AutofacContrib.DynamicProxy;
+using Bouvet.BouvetBattleRoyale.Applikasjon.Owin;
+using Bouvet.BouvetBattleRoyale.Applikasjon.Owin.Interception;
+using Microsoft.Azure.Documents;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using System;
+using System.Collections.Generic;
+using System.Collections.Specialized;
+using System.Diagnostics;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Reflection;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using System.Web.Http;
+
+namespace Bouvet.BouvetBattleRoyale.Integrasjonstester.Infrastructure
+{
+    [TestClass]
+    public class RetryInterceptionTests
+    {
+        private IContainer _container;
+        private int _retryTimes = 3;
+
+        [TestInitialize]
+        public void FørHverTest()
+        {
+            var builder = new ContainerBuilder();
+            builder.RegisterInstance(new RetryInterceptor { ShouldTry = _retryTimes }).AsSelf().SingleInstance();
+            builder.RegisterType<TestController>().EnableClassInterceptors().InterceptedBy(typeof(RetryInterceptor));
+            _container = builder.Build();
+        }
+
+        private TestController HentTestController()
+        {
+            return _container.Resolve<TestController>();
+        }
+
+        [TestMethod]
+        public void SynkronMetode_med_HttpPost_Når_den_kaster_annen_DocumentClientException_Skal_ikke_gi_retry()
+        {
+            var controller = HentTestController();
+            controller.ThrowThis = LagConcurrencyException("Not PreconditionFailed");
+
+            try
+            {
+                controller.SendInputSynkron("input");
+                Assert.Fail("Skulle kastet Exception");
+            }
+            catch (Exception ex) { }
+
+            Assert.AreEqual(1, controller.AntallKall, "Skulle ikke prøvd på nytt");
+        }
+
+        [TestMethod]
+        public void SynkronMetode_med_HttpPost_Når_den_kaster_ConcurrencyException_Skal_gi_retry()
+        {
+            var controller = HentTestController();
+            controller.ThrowThis = LagConcurrencyException();
+
+            try
+            {
+                controller.SendInputSynkron("input");
+                Assert.Fail("Skulle kastet Exception");
+            }
+            catch (Exception ex) { }
+
+            Assert.AreEqual(_retryTimes, controller.AntallKall-1, "Skulle prøvd på nytt");
+        }
+
+        [TestMethod]
+        public async Task AsynkronMetode_med_HttpPost_Når_den_kaster_ConcurrencyException_Skal_gi_retry()
+        {
+            var controller = HentTestController();
+            controller.ThrowThis = LagConcurrencyException();
+
+            try
+            {
+                await controller.SendInputAsync("input");
+                Assert.Fail("Skulle kastet Exception");
+            }
+            catch (Exception ex) { }
+
+            Assert.AreEqual(_retryTimes, controller.AntallKall - 1, "Skulle prøvd på nytt");
+        }
+
+        [TestMethod]
+        public void SynkronMetode_med_HttpPost_Når_den_kaster_ConcurrencyException_med_TimeSpan_Skal_gi_retry_og_vente()
+        {
+            var controller = HentTestController();
+
+            var retryAfterMs = 50;
+
+            controller.ThrowThis = LagConcurrencyException("PreconditionFailed", retryAfterMs);
+
+            var stopwatch = Stopwatch.StartNew();
+            try
+            {
+                controller.SendInputSynkron("input");
+                Assert.Fail("Skulle kastet Exception");
+            }
+            catch (Exception ex) { }            
+
+            Assert.AreEqual(_retryTimes, controller.AntallKall - 1, "Skulle prøvd på nytt");
+            Assert.IsTrue(stopwatch.ElapsedMilliseconds > _retryTimes * retryAfterMs, "Skulle ventet mellom hver retry");
+        }
+
+        [TestMethod]
+        public void SynkronMetode_med_HttpPost_Når_den_kaster_AnnenException_Skal_ikke_gi_retry()
+        {
+            var controller = HentTestController();
+            controller.ThrowThis = new ApplicationException("Ikke retry application exception");
+
+            try
+            {
+                controller.SendInputSynkron("input");
+                Assert.Fail("Skulle kastet Exception");
+            }
+            catch (Exception ex) {}
+
+            Assert.AreEqual(1, controller.AntallKall, "Skulle ikke prøvd på nytt");
+        }
+
+        [TestMethod]
+        public void SynkronMetode_uten_HttpPost_Når_den_kaster_AnnenException_Skal_ikke_gi_retry()
+        {
+            var controller = HentTestController();
+            controller.ThrowThis = new ApplicationException("Ikke retry application exception");
+
+            try
+            {
+                controller.HentInput("input");
+                Assert.Fail("Skulle kastet Exception");
+            }
+            catch (Exception ex) { }
+
+            Assert.AreEqual(1, controller.AntallKall, "Skulle ikke prøvd på nytt");
+        }
+
+        private Exception LagConcurrencyException(string code = "PreconditionFailed", int retryAfterMs = 0) 
+        {
+            var error = new Error { Code = code, Message = "Etag didn't match" };
+            HttpResponseHeaders headers = null;
+
+            var concurrencyException = (DocumentClientException)Activator.CreateInstance(typeof(DocumentClientException), BindingFlags.NonPublic | BindingFlags.Instance, null, new object[] { error, headers }, Thread.CurrentThread.CurrentCulture);
+
+            concurrencyException.ResponseHeaders.Add("x-ms-retry-after-ms", retryAfterMs.ToString());
+            concurrencyException.StatusCode = HttpStatusCode.PreconditionFailed;
+           
+            return new Exception("Sjekk innerException", concurrencyException);
+        }
+
+        public class TestController : ApiController
+        {
+            public Exception ThrowThis { get; set; }
+            public int AntallKall { get; set; }
+
+            private void KastExceptionHvisSatt() 
+            {
+                AntallKall++;
+
+                if (ThrowThis != null)
+                    throw ThrowThis;
+            }
+
+            [HttpGet]
+            public virtual HttpResponseMessage HentInput(string input)
+            {
+                KastExceptionHvisSatt();
+                return Request.CreateResponse(HttpStatusCode.OK, input, Configuration.Formatters.JsonFormatter);
+            }
+
+            [HttpPost]
+            public virtual HttpResponseMessage SendInputSynkron(string input)
+            {
+                KastExceptionHvisSatt();
+                return Request.CreateResponse(HttpStatusCode.OK, input, Configuration.Formatters.JsonFormatter);
+            }
+
+            [HttpPost]
+            public virtual async Task<HttpResponseMessage> SendInputAsync(string input)
+            {
+                KastExceptionHvisSatt();
+                return Request.CreateResponse(HttpStatusCode.OK, input, Configuration.Formatters.JsonFormatter);
+            }
+        }
+    }
+}

--- a/Bouvet.BouvetBattleRoyale.Integrasjonstester/packages.config
+++ b/Bouvet.BouvetBattleRoyale.Integrasjonstester/packages.config
@@ -1,6 +1,8 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <packages>
   <package id="Autofac" version="3.5.2" targetFramework="net45" />
+  <package id="AutofacContrib.DynamicProxy" version="2.3.2.632" targetFramework="net45" />
+  <package id="Castle.Core" version="3.1.0" targetFramework="net45" />
   <package id="log4net" version="2.0.3" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.2" targetFramework="net45" />
   <package id="Microsoft.AspNet.WebApi.Core" version="5.2.2" targetFramework="net45" />

--- a/Bouvet.BouvetBattleRoyale.Integrasjonstester/packages.config
+++ b/Bouvet.BouvetBattleRoyale.Integrasjonstester/packages.config
@@ -13,6 +13,7 @@
   <package id="Microsoft.Owin.Host.HttpListener" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Hosting" version="3.0.0" targetFramework="net45" />
   <package id="Microsoft.Owin.Security" version="3.0.0" targetFramework="net45" />
+  <package id="Moq" version="4.2.1409.1722" targetFramework="net45" />
   <package id="NBuilder" version="3.0.1.1" targetFramework="net45" />
   <package id="Newtonsoft.Json" version="6.0.5" targetFramework="net45" />
   <package id="Owin" version="1.0" targetFramework="net45" />


### PR DESCRIPTION
Implementasjon av retry for samtidighetsfeil. Implementert som en Interception (AOP) og registrert i Startup. Er registert på alle API-controllere. Ettersom controllere brukes direkte (ikke via interfaces), må metoder som skal interceptes være virtual.
