### PR TITLE
Cascading Konfigurasjon + instans-caching av verdier

### DIFF
--- a/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Startup.cs
+++ b/Bouvet.BouvetBattleRoyale.Applikasjon.Owin/Startup.cs
@@ -93,7 +93,7 @@
             // Note controller methods must be virtual to be intercepted
             builder.RegisterApiControllers(Assembly.GetExecutingAssembly()).EnableClassInterceptors().InterceptedBy(typeof(RetryInterceptor));
            
-            builder.RegisterType<Konfigurasjon>().As<IKonfigurasjon>();
+            builder.RegisterType<Konfigurasjon>().As<IKonfigurasjon>().SingleInstance(); // Cacher i instans
             builder.RegisterType<DocumentDbContext>().As<IDocumentDbContext>().SingleInstance();
 
             //singleton memory instance

--- a/Bouvet.BouvetBattleRoyale.Infrastruktur.Data/Konfigurasjon.cs
+++ b/Bouvet.BouvetBattleRoyale.Infrastruktur.Data/Konfigurasjon.cs
@@ -1,11 +1,38 @@
 ﻿namespace Bouvet.BouvetBattleRoyale.Infrastruktur.Data
 {
+    using System;
+    using System.Collections.Generic;
     using System.Configuration;
 
     public class Konfigurasjon : IKonfigurasjon
     {
+        private Dictionary<string, string> _settings = new Dictionary<string, string>();
+
         public string HentAppSetting(string key)
         {
+            if (!_settings.ContainsKey(key))
+                _settings.Add(key, HentSetting(key));
+
+            return _settings[key];
+        }
+
+        /// <summary>
+        /// Legger opp til at en ikke trenger å publisere url og nøkler til Azure-kontoer ved
+        /// å sjekke om setting er overstyrt i Environment-variabel. På denne måten kan en utvikler kjøre
+        /// på privat Azure-konto.
+        /// </summary>
+        private string HentSetting(string key)
+        {
+            var userValue = Environment.GetEnvironmentVariable(key, EnvironmentVariableTarget.User);
+
+            if (!string.IsNullOrEmpty(userValue))
+                return userValue;
+
+            var machineValue = Environment.GetEnvironmentVariable(key, EnvironmentVariableTarget.Machine);
+
+            if (!string.IsNullOrEmpty(machineValue))
+                return machineValue;
+
             return ConfigurationManager.AppSettings[key];
         }
     }


### PR DESCRIPTION
Kan nå overstyre appSettings med Environment-variabler for å støtte ulike/egne Azure-kontoer under utvikling. Med dette på plass, kan jeg leke med egen documentDB og teste litt rundt dokument-design og spørringer uten at det går i beina på noen andre.
